### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		],
 		"fix": [
 			"phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
-		]
+		],
+		"phpstan": "phpstan analyse --memory-limit=1G"
 	},
 	"authors": [
 		{
@@ -21,7 +22,10 @@
 		"php": ">=7.4"
 	},
 	"require-dev": {
-		"wp-coding-standards/wpcs": "^3.0"
+		"wp-coding-standards/wpcs": "^3.0",
+		"phpstan/phpstan": "^2.1",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"php-stubs/wordpress-stubs": "^6.9"
 	},
 	"config": {
 		"allow-plugins": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$url of function user_trailingslashit expects string, int\<2, max\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: taro-lead-next.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - taro-lead-next.php


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)