### PR TITLE
Add wp-plugin-audit workflow

### DIFF
--- a/.github/workflows/wp-plugin-audit.yml
+++ b/.github/workflows/wp-plugin-audit.yml
@@ -1,0 +1,14 @@
+name: WP Plugin Audit
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    uses: tarosky/workflows/.github/workflows/plugin-audit.yml@main
+    with:
+      slug: taro-lead-next
+      language: ja
+    secrets: inherit


### PR DESCRIPTION
## Summary

- WordPress.org のプラグイン健全性を月次で自動監査する `wp-plugin-audit` ワークフローを追加
- `tarosky/workflows` の共有ワークフロー `plugin-audit.yml` を呼び出し、Claude がプラグイン情報・サポートフォーラム・競合を分析してIssueを自動作成
- 毎月1日 UTC 0:00 に自動実行（`workflow_dispatch` で手動実行も可能）

## Reference

- rich-taxonomy で先行導入済み: https://github.com/tarosky/rich-taxonomy/issues?q=label%3Awp-plugin-audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)