### PR TITLE
Migrate Playground preview to shared workflows

### DIFF
--- a/.github/workflows/playground-preview-build.yml
+++ b/.github/workflows/playground-preview-build.yml
@@ -9,43 +9,7 @@ permissions:
 
 jobs:
   build:
-    name: Build Plugin ZIP
-    runs-on: ubuntu-latest
     if: >
       contains(github.event.pull_request.labels.*.name, 'playground') &&
       (github.event.action != 'labeled' || github.event.label.name == 'playground')
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools: composer
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.node-version'
-          cache: npm
-
-      - name: Install dependencies and build
-        run: |
-          composer install --no-dev --prefer-dist
-          npm ci
-          npm run package
-
-      - name: Create plugin ZIP
-        run: |
-          rsync -rc --exclude-from=.distignore ./ ./plugin-build/
-          cd plugin-build && zip -r ../taro-lead-next.zip .
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: playground-pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-          path: taro-lead-next.zip
-          if-no-files-found: error
-          retention-days: 7
+    uses: tarosky/workflows/.github/workflows/playground-preview-build.yml@main

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -12,72 +12,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish Preview
-    runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
-    steps:
-      - name: Extract PR metadata from artifact
-        id: metadata
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
-            });
-            const artifact = artifacts.data.artifacts.find(a =>
-              a.name.startsWith('playground-pr')
-            );
-            if (!artifact) {
-              core.info('No playground artifact found – build was skipped (no label).');
-              core.setOutput('found', 'false');
-              return;
-            }
-            const match = artifact.name.match(/^playground-pr(\d+)-(.+)$/);
-            if (!match) throw new Error(`Cannot parse: ${artifact.name}`);
-            const [, prNumber, commitSha] = match;
-            core.setOutput('found', 'true');
-            core.setOutput('pr-number', prNumber);
-            core.setOutput('commit-sha', commitSha);
-            core.setOutput('artifact-name', artifact.name);
-
-      - name: Expose artifact on public URL
-        if: steps.metadata.outputs.found == 'true'
-        id: expose
-        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
-        with:
-          artifact-name: ${{ steps.metadata.outputs.artifact-name }}
-          artifact-filename: taro-lead-next.zip
-          pr-number: ${{ steps.metadata.outputs.pr-number }}
-          commit-sha: ${{ steps.metadata.outputs.commit-sha }}
-          artifact-source-run-id: ${{ github.event.workflow_run.id }}
-          artifacts-to-keep: '2'
-
-      - name: Generate blueprint
-        if: steps.metadata.outputs.found == 'true'
-        id: blueprint
-        run: |
-          node - <<'NODE' >> "$GITHUB_OUTPUT"
-          const blueprint = {
-            steps: [{
-              step: 'installPlugin',
-              pluginZipFile: { resource: 'url', url: process.env.ARTIFACT_URL },
-              options: { activate: true },
-            }],
-          };
-          console.log(`blueprint=${JSON.stringify(blueprint)}`);
-          NODE
-        env:
-          ARTIFACT_URL: ${{ steps.expose.outputs.artifact-url }}
-
-      - name: Post preview comment
-        if: steps.metadata.outputs.found == 'true'
-        uses: WordPress/action-wp-playground-pr-preview@v2
-        with:
-          mode: comment
-          blueprint: ${{ steps.blueprint.outputs.blueprint }}
-          pr-number: ${{ steps.metadata.outputs.pr-number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: tarosky/workflows/.github/workflows/playground-preview-publish.yml@main


### PR DESCRIPTION
## Summary

- インラインだった Playground Preview ワークフロー（計135行）を `tarosky/workflows` の共有リソースに抽出
- 各 caller は14行/17行のミニマルな構成に（計31行、-103行）
- 機能的な変更なし — 共有ワークフローへの委譲のみ

## Test plan

- [ ] `playground` ラベルで Build が実行されること
- [ ] Publish が続いて実行され、PR にプレビューコメントが投稿されること
- [ ] プレビューリンクが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)