### PR TITLE
Use npm ci --ignore-scripts in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies and build Assets
         run: |
           composer install --no-dev --prefer-dist
-          npm install
+          npm ci --ignore-scripts
           npm run package
 
       - name: Generate readme.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           node-version-file: '.node-version'
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps


### PR DESCRIPTION
## Summary
- Replace `npm install` / `npm ci` with `npm ci --ignore-scripts` in deploy and test workflows
- Prevents execution of postinstall/lifecycle scripts during CI, mitigating supply chain attacks
- No functional impact: CI doesn't need husky hooks or other lifecycle scripts

## Test plan
- [ ] Deploy workflow still builds correctly on next release
- [ ] Test workflow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)